### PR TITLE
Fix: Install dev dependencies for frontend Docker build

### DIFF
--- a/poker-academy/Dockerfile
+++ b/poker-academy/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /app
 # Copiar package.json e package-lock.json
 COPY package*.json ./
 
-# Instalar dependências
-RUN npm ci --only=production
+# Instalar dependências (incluindo dev dependencies para build)
+RUN npm ci
 
 # Copiar código fonte
 COPY . .


### PR DESCRIPTION
## 🐛 Fix: Frontend Docker Build Issue

### Problem
The frontend Docker build was failing during deployment because TailwindCSS and other dev dependencies were not being installed. The build process requires dev dependencies to compile the React application properly.

**Error encountered:**
```
Loading PostCSS "tailwindcss" plugin failed: Cannot find module 'tailwindcss'
```

### Solution
Changed the npm install command in the frontend Dockerfile from `npm ci --only=production` to `npm ci` to include dev dependencies during the build stage.

### Changes Made
- **File**: `poker-academy/Dockerfile`
- **Line 12**: Modified npm install command
- **Before**: `RUN npm ci --only=production`
- **After**: `RUN npm ci`

### Technical Details
- The multi-stage Docker build requires dev dependencies in the builder stage
- TailwindCSS and other build tools are classified as dev dependencies in package.json
- The final production image still only contains the built static files served by NGINX
- No impact on final image size due to multi-stage build architecture

### Testing
- ✅ Docker build process now completes successfully
- ✅ All required dependencies (including TailwindCSS) are available during build
- ✅ Final image size remains optimized (dev dependencies are not in final stage)
- ✅ Deployment pipeline can proceed without build errors

### Impact
- **Fixes**: Deployment pipeline Docker build failure
- **Enables**: Successful production deployments
- **Maintains**: Optimized final image size
- **No Breaking Changes**: Only affects build process, not runtime

### Deployment Context
This fix was identified during the deployment process to the production server (142.93.206.128). The build was failing at the React compilation stage due to missing dev dependencies required by PostCSS and TailwindCSS.

**Ready for merge and deployment** 🚀

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author